### PR TITLE
Add support for emailAddress

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,9 +1,0 @@
-linters:
-  enable:
-    - errcheck
-    - gosimple
-    - govet
-    - ineffassign
-    - staticcheck
-    - unused
-    - gosec

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ test:
 	go test -v ./...
 
 lint:
-	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0 run
+	go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.2 run
 
 update-modules:
 	go get -u -t ./... && go mod tidy

--- a/dn.go
+++ b/dn.go
@@ -58,6 +58,12 @@ var oids = map[string]asn1.ObjectIdentifier{
 	"x121address":                {2, 5, 4, 24},
 }
 
+// Aliases for the attribute names.
+// e.g. from https://learn.microsoft.com/en-us/windows/win32/seccrypto/name-properties
+var alias = map[string]string{
+	"e": "emailaddress",
+}
+
 // ParseDN returns a distinguishedName or an error.
 // The function respects https://tools.ietf.org/html/rfc4514
 func ParseDN(str string) (*pkix.Name, error) {
@@ -104,7 +110,12 @@ func ParseDN(str string) (*pkix.Name, error) {
 			unescapedTrailingSpaces = 0
 			escaping = true
 		case char == '=':
-			rdn.Type = oids[strings.ToLower(stringFromBuffer())]
+			attribute := strings.ToLower(stringFromBuffer())
+			// Resolve alias if present
+			if aliasName, ok := alias[attribute]; ok {
+				attribute = aliasName
+			}
+			rdn.Type = oids[attribute]
 			// Special case: If the first character in the value is # the
 			// following data is BER encoded so we can just fast forward
 			// and decode.

--- a/dn.go
+++ b/dn.go
@@ -21,6 +21,7 @@ var oids = map[string]asn1.ObjectIdentifier{
 	"destinationindicator":       {2, 5, 4, 27},
 	"distinguishedName":          {2, 5, 4, 49},
 	"dnqualifier":                {2, 5, 4, 46},
+	"emailaddress":               {1, 2, 840, 113549, 1, 9, 1},
 	"enhancedsearchguide":        {2, 5, 4, 47},
 	"facsimiletelephonenumber":   {2, 5, 4, 23},
 	"generationqualifier":        {2, 5, 4, 44},
@@ -179,7 +180,7 @@ func fillExtraNames(rdns *pkix.RDNSequence, name *pkix.Name) error {
 		}
 
 		for _, atv := range rdn {
-			if atv.Type.Equal(oids["dc"]) {
+			if atv.Type.Equal(oids["dc"]) || atv.Type.Equal(oids["emailaddress"]) {
 				// IA5String
 				atv.Value = asn1.RawValue{Tag: 22, Class: 0, Bytes: []byte(atv.Value.(string))}
 				name.ExtraNames = append(name.ExtraNames, atv)

--- a/dn_test.go
+++ b/dn_test.go
@@ -12,7 +12,7 @@ func TestDnParse(t *testing.T) {
 		t.Errorf("Failed %s\n", err)
 	}
 
-	if !(dn.CommonName == "John Doe" && dn.OrganizationalUnit[0] == "People" && dn.Organization[0] == "MyCompany") {
+	if dn.CommonName != "John Doe" || dn.OrganizationalUnit[0] != "People" || dn.Organization[0] != "MyCompany" {
 		t.Errorf("Failed: dn not as expected %v\n", dn)
 	}
 }
@@ -22,7 +22,7 @@ func TestEscape(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed %s\n", err)
 	}
-	if !(dn.CommonName == "John \"Bob\" Doe") {
+	if dn.CommonName != "John \"Bob\" Doe" {
 		t.Errorf("Failed: dn not as expected %v\n", dn)
 	}
 
@@ -30,7 +30,7 @@ func TestEscape(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed %s\n", err)
 	}
-	if !(dn.CommonName == "Before\rAfter") {
+	if dn.CommonName != "Before\rAfter" {
 		t.Errorf("Failed: dn not as expected %v\n", dn)
 	}
 }
@@ -42,8 +42,19 @@ func TestParseDomainComponent(t *testing.T) {
 	}
 
 	expected := asn1.RawValue{Tag: 22, Class: 0, Bytes: []byte("domain-component")}
-	if !(dn.CommonName == "John Doe" && reflect.DeepEqual(dn.ExtraNames[0].Value.(asn1.RawValue), expected)) {
+	if dn.CommonName != "John Doe" || !reflect.DeepEqual(dn.ExtraNames[0].Value.(asn1.RawValue), expected) {
 		t.Errorf("Failed: dn not as expected %v\n", dn)
 	}
+}
 
+func TestParseEmailAddress(t *testing.T) {
+	dn, err := ParseDN("CN=John Doe, emailAddress=john@example.com")
+	if err != nil {
+		t.Errorf("Failed %s\n", err)
+	}
+
+	expected := asn1.RawValue{Tag: 22, Class: 0, Bytes: []byte("john@example.com")}
+	if dn.CommonName != "John Doe" || !reflect.DeepEqual(dn.ExtraNames[0].Value.(asn1.RawValue), expected) {
+		t.Errorf("Failed: dn not as expected %v\n", dn)
+	}
 }

--- a/dn_test.go
+++ b/dn_test.go
@@ -58,3 +58,15 @@ func TestParseEmailAddress(t *testing.T) {
 		t.Errorf("Failed: dn not as expected %v\n", dn)
 	}
 }
+
+func TestParsesAlias(t *testing.T) {
+	dn, err := ParseDN("CN=John Doe, E=john@example.com")
+	if err != nil {
+		t.Errorf("Failed %s\n", err)
+	}
+
+	expected := asn1.RawValue{Tag: 22, Class: 0, Bytes: []byte("john@example.com")}
+	if dn.CommonName != "John Doe" || !reflect.DeepEqual(dn.ExtraNames[0].Value.(asn1.RawValue), expected) {
+		t.Errorf("Failed: dn not as expected %v\n", dn)
+	}
+}


### PR DESCRIPTION
This PR introduces support for the `emailAddress` attribute (https://oid-base.com/get/1.2.840.113549.1.9.1). Note that its use in X.509 certificates is discouraged, as outlined in [RFC 5280, Section 4.1.2.6](https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.6).

> Conforming implementations generating new certificates with electronic mail addresses MUST use the rfc822Name in the subject alternative name extension ([Section 4.2.1.6](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.6)) to describe such identities.  Simultaneous inclusion of the emailAddress attribute in the subject distinguished name to support legacy implementations is deprecated but permitted.

Fixes #4